### PR TITLE
Right align the language dropdown menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
         <% else  # if there are more than 3 languages, show a dropdown for changing languages  %>
           <li class="nav-item dropdown">
             <a href="#" class="nav-link nav-locale dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Languages <span class="caret"></span></a>
-            <div class="dropdown-menu" role="menu">
+            <div class="dropdown-menu dropdown-menu-right" role="menu">
               <% locales.each do |locale| %>
                 <a href="<%= url_for(permitted_params.merge(locale: locale)) %>" class="dropdown-item">
                   <span class="glyphicon glyphicon-ok" style="font-size: 0.8em; margin-left: -1em; margin-right: 4px; <%= (I18n.locale != locale) ? 'visibility: hidden;' : '' %>"></span>


### PR DESCRIPTION
When there are more than 3 languages available, we show a dropdown menu for changing languages. Currently, part of the menu is off the screen. This PR fixes that by right aligning the menu.

Before:
![before](https://user-images.githubusercontent.com/226473/105780957-7f0ebb80-5f26-11eb-89e4-40ebf6de7b3b.png)

After:
![after](https://user-images.githubusercontent.com/226473/105780967-82a24280-5f26-11eb-8e8b-07fd8a478215.png)
