### PR TITLE
Missing-voter-fix

### DIFF
--- a/app/controllers/admin/elections_controller.rb
+++ b/app/controllers/admin/elections_controller.rb
@@ -473,9 +473,11 @@ module Admin
 
     def analytics_vote_count_table(election, utc_offset)
       has_external_vote_count = !election.projects.where('external_vote_count > 0').empty?
+      workflow_first = @election.config[:workflow].flatten[0]
 
       voters_by_date_and_origin = election.valid_voters
         .select("DATE(CONVERT_TZ(created_at, '+00:00', '#{utc_offset}')) AS date, authentication_method, location_id, COUNT(*) AS vote_count")
+        .where.not(stage: workflow_first)
         .group(:date, :authentication_method, :location_id)
       origins = voters_by_date_and_origin.map(&:origin).uniq
       columns = origins + (has_external_vote_count ? ['External Votes'] : []) + ['Total']

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -2,7 +2,7 @@ class Election < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :categories, dependent: :destroy
   has_many :voters, dependent: :destroy
-  has_many :valid_voters, -> { where("void = 0 AND stage IS NOT NULL AND stage != 'approval'") }, class_name: 'Voter'
+  has_many :valid_voters, -> { where("void = 0 AND stage IS NOT NULL") }, class_name: 'Voter' ###AND stage != 'approval'
   has_many :voter_registration_records, dependent: :destroy
   has_many :code_batches, dependent: :destroy
   has_many :codes, through: :code_batches


### PR DESCRIPTION
Fixed 2 things.

a) Voters which left the election during the "approval" test ballot phase are still counted.
b) Voters which did not submit the actual ballot are not counted.