### PR TITLE
voters.void field is of type boolean ; check fails because of testing voters.void = 0 

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -6,7 +6,7 @@ module Admin
       if current_user
         elections = Election
           .select("elections.*, COUNT(voters.id) AS voter_count")
-          .joins("LEFT OUTER JOIN voters ON voters.election_id = elections.id AND voters.void = 0")
+          .joins("LEFT OUTER JOIN voters ON voters.election_id = elections.id AND voters.void = false")
           .group("elections.id")
           .select { |election| current_user.admin?(election) || current_user.volunteer?(election) }
         elections = elections.natural_sort_by(&:name)


### PR DESCRIPTION
While logging into the admin panel using the route `/admin`, the control of the code transfers to `controllers/admin/home_controller.rb` and checks the join on `elections` and `voters` tables. The selection of the query result fails due to mismatch datatype. The schema for `voters` defines `void` as boolean datatype but the join condition on `elections` and `voters` table is checking `voters.void` as integer datatype i.e.

`app/controllers/admin/home_controller.rb#L9` is being coded as `.joins("LEFT OUTER JOIN voters ON voters.election_id = elections.id AND voters.void = 0")` and thus returns an error.

Fixed this error by simply setting `voters.void = false`

I am not sure if this is only the case in my machine. But yes, please do check!

Thanks!

