### PR TITLE
Add data retention and archiving policy to terms of service

### DIFF
--- a/app/views/home/terms.html.erb
+++ b/app/views/home/terms.html.erb
@@ -31,7 +31,7 @@
 </p>
 <h2> Data Retention and Archiving </h2>
 <p>
-To protect voter privacy and data safety, SCDT reserves the right to irreversibly anonymize personal data (including IP addresses, user device information, and voter registration data) collected through the Platform within 6 months of an election\'s end date.
+To protect voter privacy and data safety, we reserve the right to irreversibly anonymize personal data (including IP addresses, user device information, and voter registration data) collected through the Platform at any point after 6 months from an election’s end date.
 </p>
 
 <h2> Data use </h2>

--- a/app/views/home/terms.html.erb
+++ b/app/views/home/terms.html.erb
@@ -29,6 +29,11 @@
 <h2> No warranties </h2>
 <p> The Platform is provided ‘as is’ without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Platform or the use of the Platform.
 </p>
+<h2> Data Retention and Archiving </h2>
+<p>
+To protect voter privacy and data safety, SCDT reserves the right to irreversibly anonymize personal data (including IP addresses, user device information, and voter registration data) collected through the Platform within 6 months of an election\'s end date.
+</p>
+
 <h2> Data use </h2>
 <p>
 Stanford and SCDT take personal privacy seriously. The Platform is designed with the goal of collecting only the personally identifiable information of Users that SCDT determines is reasonably required for the operation and functionality of the Platform, for the purposes of the Process established by its Organizer, and for achieving the learning and other objectives of the Research. Generally speaking, these are groups of data that the Platform collects:


### PR DESCRIPTION
This is an updated ToS given the recent archiving change.

I thought to accompany it with the following email to admins:


> Hello,
> 
> We’re writing to let you know that we’ve updated the Terms of Service for the PB Stanford Platform.
> 
> **What’s changed:** We’ve added a Data Retention and Archiving policy. To protect voter privacy and data security, SCDT may irreversibly anonymize personal data collected through the Platform, including IP addresses, device information, and voter registration data, at any point after 6 months from an election’s end date.
> 
> You can read the full Terms of Service here: https://pbstanford.org/terms
> 
> Please feel free to reach out to us at contact@pbstanford.org if you have any questions.
> 
> Thank you,
> The Stanford Crowdsourced Democracy Team